### PR TITLE
Fixed bugs with optional parameters and empty names

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+slate-irc

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,0 @@
-slate-irc

--- a/index.js
+++ b/index.js
@@ -233,7 +233,11 @@ Client.prototype.part = function(channels, msg, fn){
     msg = '';
   }
 
-  this.write('PART ' + toArray(channels).join(',') + ' :' + msg, fn);
+  if(msg) {
+    this.write('PART ' + toArray(channels).join(',') + ' :' + msg, fn);
+  } else {
+    this.write('PART ' + toArray(channels).join(','), fn);
+  }
 };
 
 /**
@@ -276,7 +280,12 @@ Client.prototype.kick = function(channels, nicks, msg, fn){
 
   channels = toArray(channels).join(',');
   nicks = toArray(nicks).join(',');
-  this.write('KICK ' + channels + ' ' + nicks + ' :' + msg, fn);
+
+  if(msg) {
+    this.write('KICK ' + channels + ' ' + nicks + ' :' + msg, fn);
+  } else {
+    this.write('KICK ' + channels + ' ' + nicks, fn);
+  }
 };
 
 /**

--- a/lib/plugins/names.js
+++ b/lib/plugins/names.js
@@ -45,7 +45,7 @@ module.exports = function(){
         case 'RPL_ENDOFNAMES':
           var chan = msg.params.split(' ')[1].toLowerCase();
           debug('emit "names" for %s', chan);
-          var e = { channel: chan, names: map[chan] };
+          var e = { channel: chan, names: map[chan] || [] };
           var cb = irc.nameCallbacks[chan];
 
           if (cb) cb(e)
@@ -56,7 +56,7 @@ module.exports = function(){
       }
     });
   }
-}
+};
 
 /**
  * Fetch names for `channel` and invoke `fn(err, names)`.
@@ -70,10 +70,12 @@ function names(channel, fn) {
   var self = this;
   channel = channel.toLowerCase();
 
-  this.nameCallbacks[channel] = function(e){
-    delete self.nameCallbacks[channel];
-    fn(null, e.names);
-  };
+  if(fn) {
+    this.nameCallbacks[channel] = function(e){
+      delete self.nameCallbacks[channel];
+      fn(null, e.names);
+    };
+  }
 
   this.write('NAMES ' + channel);
 }


### PR DESCRIPTION
part / kick messages are optional and would send an 'undefined' string if not specified

allow the names extension function to have 'fn' as an optional parameter so that the event system can handle the response (otherwise it throws an error since it tries to call an undefined fn)

Also, some servers (at least unrealircd) just respond with a RPL_ENDOFNAMES if the request is for a channel that the user is not in. So map[chan] will be undefined. In that case with this PR it will return an empty array instead, for consistency.