### PR TITLE
Check for callback to let the on('names') propagate

### DIFF
--- a/lib/plugins/names.js
+++ b/lib/plugins/names.js
@@ -70,10 +70,12 @@ function names(channel, fn) {
   var self = this;
   channel = channel.toLowerCase();
 
-  this.nameCallbacks[channel] = function(e){
-    delete self.nameCallbacks[channel];
-    fn(null, e.names);
-  };
+  if (fn) {
+    this.nameCallbacks[channel] = function(e){
+      delete self.nameCallbacks[channel];
+      fn(null, e.names);
+    };
+  }
 
   this.write('NAMES ' + channel);
 }


### PR DESCRIPTION
If no callback is specified, the program crashes, even though names.js is set up to emit a names event (line 52).