### PR TITLE
fix RPL_AWAY

### DIFF
--- a/lib/plugins/away.js
+++ b/lib/plugins/away.js
@@ -16,9 +16,9 @@ module.exports = function() {
   return function(irc) {
     irc.on('data', function(msg) {
       if ('RPL_AWAY' != msg.command) return;
+      var params = msg.params.split(' ');
       var e = {};
-      e.nick = utils.nick(msg);
-      e.hostmask = utils.hostmask(msg);
+      e.nick = params[1];
       e.message = msg.trailing;
       irc.emit('away', e);
     });

--- a/test/away.js
+++ b/test/away.js
@@ -8,16 +8,12 @@ describe('away()', function() {
       var client = irc(stream);
 
       client.on('away', function(e) {
-        e.nick.should.equal('loki');
+        e.nick.should.equal('colinm');
         e.message.should.eql('brb food time');
-        e.hostmask.nick.should.equal('loki');
-        e.hostmask.username.should.equal('~user');
-        e.hostmask.hostname.should.equal('example.com');
-        e.hostmask.string.should.equal('loki!~user@example.com');
         done();
       });
 
-      stream.write(':loki!~user@example.com 301 colinm cmilhench :brb food time\r\n');
+      stream.write(':irc.host.net 301 me colinm :brb food time\r\n');
     });
   });
 });


### PR DESCRIPTION
the test case for `RPL_AWAY` is wrong

oddly enough, a better test and proper behaviour was already [in whois](https://github.com/slate/slate-irc/blob/0079ce8725f33bdb4ade7064dbc481c992ad1fb8/test/whois.js#L30)