### PR TITLE
Prevent cross IRC scripting vulnerability

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,6 +82,18 @@ function Client(stream, parser, encoding) {
 Client.prototype.__proto__ = Emitter.prototype;
 
 /**
+ * Write `str` without checking for '\r' or '\n' and invoke `fn(err)`.
+ *
+ * @param {String} str
+ * @param {Function} [fn]
+ * @api public
+ */
+
+Client.prototype.writeUnsafe = function(str, fn) {
+  this.stream.write(str + '\r\n', fn);
+};
+
+/**
  * Write `str` and invoke `fn(err)`.
  *
  * @param {String} str
@@ -94,7 +106,7 @@ Client.prototype.write = function(str, fn) {
     fn && fn(new Error("The parameter to write() must not contain any '\\n' or '\\r'."));
     return;
   }
-  this.stream.write(str + '\r\n', fn);
+  this.writeUnsafe(str, fn);
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -90,6 +90,10 @@ Client.prototype.__proto__ = Emitter.prototype;
  */
 
 Client.prototype.write = function(str, fn) {
+  if (str.indexOf('\n') != -1 || str.indexOf('\r') != -1) {
+    fn && fn(new Error("The parameter to write() must not contain any '\\n' or '\\r'."));
+    return;
+  }
   this.stream.write(str + '\r\n', fn);
 };
 

--- a/lib/plugins/disconnect.js
+++ b/lib/plugins/disconnect.js
@@ -15,6 +15,9 @@ module.exports = function() {
       irc.emit('disconnect');
     });
 
+    // Do nothing when given stream cannot perform setTimeout() operation
+    if (stream.setTimeout == null) { return; }
+
     stream.setTimeout(ms);
 
     stream.on('timeout', function() {

--- a/test/write.js
+++ b/test/write.js
@@ -1,0 +1,24 @@
+var irc = require('..');
+var Stream = require('stream').PassThrough;
+var should = require('should');
+
+describe('client.write()', function() {
+  it('should err when newline characters are given', function(done) {
+    var stream = new Stream;
+    var client = irc(stream);
+
+    var cnt = 0;
+    var tests = [
+      'NICK tobi\nUSER user :example.com',
+      'PRIVMSG #loki :Hello :)\r\nNewline :(',
+      'PRIVMSG #lock :Some servers accept \r as a line delimiter'
+      ];
+    tests.forEach(function(msg) {
+      client.write(msg, function(err) {
+        should(err).not.null();
+        cnt++;
+        if (cnt >= tests.length) done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This patch prevents users from being attacked by cross IRC scripting vulnerability.

Category | Current | Proposal
----|----|----
Unsafe version | `write()` sends any message that programmer requested. | `writeUnsafe()` sends any message that programmer requested.
Safe version | **There is _NO_ safe version** | `write()` sends only messages which do not contain `\n` or `\r`s.

#### Details

```js
irc.send('#slate', `Hi ${msg}, I'm robot!`);
```

If msg was `blablabla\r\nMODE #slate -o AnotherUser\r\nPRIVMSG #hyeon :`, slate-irc will send the payloads below:

```irc
PRIVMSG #slate :blablabla\r\n
MODE #slate -o AnotherUser\r\n
PRIVMSG #hyeon :I'm robot!\r\n
```

This will result to deoping `AnotherUser`, which is undesirable. Using this technique, attackers can use vulnerable IRC bot using slate-irc to deop, kick, or ban another users. This should be fixed.

If this PR is merged, `write()` method will cause an error if given parameter contains newlines. If programmer intendedly wants to write a message with newlines, they will have to use the `writeUnsafe()` method.

CC @VBChunguk 

<br>

*Waiting for review*